### PR TITLE
Don't round ancestral and noise_mult

### DIFF
--- a/sampler_lcm_alt.py
+++ b/sampler_lcm_alt.py
@@ -80,8 +80,8 @@ class SamplerLCMAlternative:
     def INPUT_TYPES(s):
         return {"required":
                     {"euler_steps": ("INT", {"default": 0, "min": -10000, "max": 10000}),
-                     "ancestral": ("FLOAT", {"default": 0, "min": 0, "max": 1.0, "step": 0.01, "round": True}),
-                     "noise_mult": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 2.0, "step": 0.001, "round": True}),
+                     "ancestral": ("FLOAT", {"default": 0, "min": 0, "max": 1.0, "step": 0.01, "round": False}),
+                     "noise_mult": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 2.0, "step": 0.001, "round": False}),
                     }
                }
     RETURN_TYPES = ("SAMPLER",)


### PR DESCRIPTION
Seems like this locks the values at 1.0, 2.0 etc., so I don't think we want that here. I've also changed the step for `noise_mult` to 0.01 because lower values make it look like clicking the `<` and `>` buttons doesn't do anything. 