### PR TITLE
ComfyUI deprecated 'calculate_sigmas_scheduler' Fix jojkaart#5

### DIFF
--- a/sampler_lcm_alt.py
+++ b/sampler_lcm_alt.py
@@ -78,7 +78,7 @@ class LCMScheduler:
             total_steps = int(steps/denoise)
 
         comfy.model_management.load_models_gpu([model])
-        sigmas = comfy.samplers.calculate_sigmas_scheduler(model.model, "sgm_uniform", total_steps).cpu()
+        sigmas = comfy.samplers.calculate_sigmas(model.model.get_model_object("model_sampling"), "sgm_uniform", total_steps).cpu()
         sigmas = sigmas[-(steps + 1):]
         return (sigmas, )
 

--- a/sampler_lcm_alt.py
+++ b/sampler_lcm_alt.py
@@ -78,7 +78,7 @@ class LCMScheduler:
             total_steps = int(steps/denoise)
 
         comfy.model_management.load_models_gpu([model])
-        sigmas = comfy.samplers.calculate_sigmas(model.model.get_model_object("model_sampling"), "sgm_uniform", total_steps).cpu()
+        sigmas = comfy.samplers.calculate_sigmas(model.get_model_object("model_sampling"), "sgm_uniform", total_steps).cpu()
         sigmas = sigmas[-(steps + 1):]
         return (sigmas, )
 


### PR DESCRIPTION
ComfyUI deprecated `calculate_sigmas_scheduler` now uses `calculate_sigmas` instead.