### PR TITLE
Update Github Action for Publishing to Comfy Registry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,15 +7,19 @@ on:
     paths:
       - "pyproject.toml"
 
+permissions:
+  issues: write
+
 jobs:
   publish-node:
     name: Publish Custom Node to registry
     runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'jojkaart' }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4
       - name: Publish Custom Node
-        uses: Comfy-Org/publish-node-action@main
+        uses: Comfy-Org/publish-node-action@v1
         with:
           ## Add your own personal access token to your Github Repository secrets and reference it here.
           personal_access_token: ${{ secrets.REGISTRY_ACCESS_TOKEN }}


### PR DESCRIPTION
Hey! My name is Robin and I'm from [comfy-org](https://comfy.org/)! We would love to have you join the Comfy Registry, a public collection of custom nodes which lets authors publish nodes by version and automate testing against existing workflows. This PR updates the Github Action `publish.yml` to ensure latest ComfyUI Community Standard.

## Updates:

1. **Issue Creating Permission**: Ensures that the workflow can open issues to report publishing states or warnings, facilitating better communication and issue tracking.

```diff
+ # auto issue permission, for Comfy CustomNode registry publishing state
+ permissions:
+   issues: write
```

2. **Conditional Execution**: Only runs the publish job in author’s repo, defaults to repo owner, reference issue here: - [Forks problem: add an organisation or owner check to run the action · Issue #2 · Comfy-Org/publish-node-action](https://github.com/Comfy-Org/publish-node-action/issues/2)

```diff
+     if: ${{ github.repository_owner == 'jojkaart' }}
```

3. **Versioning**: We use explicity version number after stable release, using a stable release version of the action reduces the
   risk of unexpected behavior from changes in the action's main branch.

```diff
-     uses: Comfy-Org/publish-node-action@~~main~~
+     uses: Comfy-Org/publish-node-action@v1
```

## Learn More

Please message me on Discord at robin or join our [server](https://discord.com/invite/comfyorg) server if you have any questions! For more information, visit the official Comfy-Org blog: [ComfyUI Blog](https://blog.comfy.org/).